### PR TITLE
Recipe to revert the box back to sheeting

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -30,6 +30,11 @@ minetest.register_craft( {
         },
 })
 
+minetest.register_craft( {
+        output = "homedecor:plastic_sheeting 2",
+        recipe = {{ "plasticbox:plasticbox" }},
+})
+
 minetest.register_lbm({
 	name = "plasticbox:convert_colors",
 	label = "Convert plastic boxes to use param2 color",


### PR DESCRIPTION
I got caught that I hesitate to craft boxes because cannot be reversed. If the node could be reversed the boxes could be used as more compact storage for plastic, and maybe used more..

Mathematically correct 8 cheeting => 4 boxes => 4x2 conversion back